### PR TITLE
Add terraform specs for AWS deployments

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+source =
+    example_app
+omit =
+    tests/*
+    example_app/version.py

--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,40 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# lambda .zip archives
+terraform/*.zip
+
+# Crash log files
+crash.log
+
+# Ignore any .tfvars files that are generated automatically for each Terraform run. Most
+# .tfvars files are managed as part of configuration and so should be included in
+# version control.
+#
+# example.tfvars
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+#
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/example_app/main.py
+++ b/example_app/main.py
@@ -7,6 +7,9 @@ from mangum import Mangum
 from example_app.api.api_v1.api import router as api_router
 from example_app.core.config import API_V1_STR
 from example_app.core.config import PROJECT_NAME
+from example_app.version import __version__
+
+VERSION = __version__
 
 app = FastAPI(
     title=PROJECT_NAME,
@@ -14,6 +17,7 @@ app = FastAPI(
     # openapi_prefix="/Prod"
 )
 
+app.VERSION = VERSION
 
 app.include_router(api_router, prefix=API_V1_STR)
 
@@ -26,10 +30,10 @@ def pong():
     This will let the user know that the service is operational.
 
     And this path operation will:
-    * show a lifesign
+    * show a life-sign
 
     """
-    return {"ping": "pong!"}
+    return {"ping": "pong!", "version": app.VERSION}
 
 
 def get_asgi_handler(fast_api: FastAPI) -> Optional[Mangum]:

--- a/example_app/version.py
+++ b/example_app/version.py
@@ -1,0 +1,12 @@
+# fmt: off
+"""
+A version module managed by the invoke-release task
+
+See also tasks.py
+"""
+
+from __future__ import unicode_literals
+
+__version_info__ = (0, 1, 0)
+__version__ = '-'.join(filter(None, ['.'.join(map(str, __version_info__[:3])), (__version_info__[3:] or [None])[0]]))
+# fmt: on

--- a/poetry.lock
+++ b/poetry.lock
@@ -12,7 +12,7 @@ description = "Better dates & times for Python"
 name = "arrow"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.15.5"
+version = "0.15.6"
 
 [package.dependencies]
 python-dateutil = "*"
@@ -23,16 +23,16 @@ description = "An abstract syntax tree for Python with inference support."
 name = "astroid"
 optional = false
 python-versions = ">=3.5.*"
-version = "2.4.0"
+version = "2.3.0"
 
 [package.dependencies]
-lazy-object-proxy = ">=1.4.0,<1.5.0"
-six = ">=1.12,<2.0"
-wrapt = ">=1.11,<2.0"
+lazy-object-proxy = "*"
+six = "*"
+wrapt = "*"
 
 [package.dependencies.typed-ast]
-python = "<3.8"
-version = ">=1.4.0,<1.5"
+python = ">=3.7,<3.8"
+version = ">=1.3.0"
 
 [[package]]
 category = "dev"
@@ -439,6 +439,30 @@ testing = ["packaging", "importlib-resources"]
 
 [[package]]
 category = "dev"
+description = "Pythonic task execution"
+name = "invoke"
+optional = false
+python-versions = "*"
+version = "0.22.1"
+
+[[package]]
+category = "dev"
+description = "Reusable Invoke-based command-line release tasks for libraries and services"
+name = "invoke-release"
+optional = false
+python-versions = "*"
+version = "4.5.2"
+
+[package.dependencies]
+invoke = ">=0.22.0,<0.23.0"
+six = ">=1.11.0,<1.12.0"
+wheel = ">=0.31.1,<0.32.0"
+
+[package.extras]
+testing = ["pytest"]
+
+[[package]]
+category = "dev"
 description = "A Python utility / library to sort Python imports."
 name = "isort"
 optional = false
@@ -692,14 +716,13 @@ description = "python code static checker"
 name = "pylint"
 optional = false
 python-versions = ">=3.5.*"
-version = "2.5.0"
+version = "2.4.4"
 
 [package.dependencies]
-astroid = ">=2.4.0,<=2.5"
+astroid = ">=2.3.0,<2.4"
 colorama = "*"
 isort = ">=4.2.5,<5"
 mccabe = ">=0.6,<0.7"
-toml = ">=0.7.1"
 
 [[package]]
 category = "dev"
@@ -875,8 +898,8 @@ category = "dev"
 description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.14.0"
+python-versions = "*"
+version = "1.11.0"
 
 [[package]]
 category = "main"
@@ -978,7 +1001,7 @@ description = "Virtual Python Environment builder"
 name = "virtualenv"
 optional = false
 python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
-version = "20.0.18"
+version = "20.0.19"
 
 [package.dependencies]
 appdirs = ">=1.4.3,<2"
@@ -991,8 +1014,8 @@ python = "<3.8"
 version = ">=0.12,<2"
 
 [package.extras]
-docs = ["sphinx (>=2.0.0,<3)", "sphinx-argparse (>=0.2.5,<1)", "sphinx-rtd-theme (>=0.4.3,<1)", "towncrier (>=19.9.0rc1)", "proselint (>=0.10.2,<1)"]
-testing = ["pytest (>=4.0.0,<6)", "coverage (>=4.5.1,<6)", "pytest-mock (>=2.0.0,<3)", "pytest-env (>=0.6.2,<1)", "pytest-timeout (>=1.3.4,<2)", "packaging (>=20.0)", "xonsh (>=0.9.16,<1)"]
+docs = ["sphinx (>=3)", "sphinx-argparse (>=0.2.5)", "sphinx-rtd-theme (>=0.4.3)", "towncrier (>=19.9.0rc1)", "proselint (>=0.10.2)"]
+testing = ["pytest (>=4)", "coverage (>=5)", "coverage-enable-subprocess (>=1)", "pytest-xdist (>=1.31.0)", "pytest-mock (>=2)", "pytest-env (>=0.6.2)", "pytest-randomly (>=1)", "pytest-timeout", "packaging (>=20.0)", "xonsh (>=0.9.16)"]
 
 [[package]]
 category = "dev"
@@ -1035,13 +1058,15 @@ watchdog = ["watchdog"]
 
 [[package]]
 category = "dev"
-description = "A built-package format for Python"
+description = "A built-package format for Python."
 name = "wheel"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "0.34.2"
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.31.1"
 
 [package.extras]
+faster-signatures = ["ed25519ll"]
+signatures = ["keyring", "keyrings.alt", "pyxdg"]
 test = ["pytest (>=3.0.0)", "pytest-cov"]
 
 [[package]]
@@ -1074,7 +1099,7 @@ docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
 testing = ["jaraco.itertools", "func-timeout"]
 
 [metadata]
-content-hash = "65ca8343f84a11ce7aff1f9bda75dc5d10d3c107cca038e079e2e437aa7adf9d"
+content-hash = "3ca0da0aac9ceda5c34868f7e2f667c4203b584b8f7e42fe6800fa7cd30e8ad2"
 python-versions = "~3.7.0"
 
 [metadata.files]
@@ -1083,12 +1108,12 @@ appdirs = [
     {file = "appdirs-1.4.3.tar.gz", hash = "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92"},
 ]
 arrow = [
-    {file = "arrow-0.15.5-py2.py3-none-any.whl", hash = "sha256:70729bcc831da496ca3cb4b7e89472c8e2d27d398908155e0796179f6d2d41ee"},
-    {file = "arrow-0.15.5.tar.gz", hash = "sha256:5390e464e2c5f76971b60ffa7ee29c598c7501a294bc9f5e6dadcb251a5d027b"},
+    {file = "arrow-0.15.6-py2.py3-none-any.whl", hash = "sha256:a24c1de90850f6fb2033fd6bf8a11f281e84cb54825e5eabdda219e673b52aac"},
+    {file = "arrow-0.15.6.tar.gz", hash = "sha256:eb5d339f00072cc297d7de252a2e75f272085d1231a3723f1026d1fa91367118"},
 ]
 astroid = [
-    {file = "astroid-2.4.0-py3-none-any.whl", hash = "sha256:2fecea42b20abb1922ed65c7b5be27edfba97211b04b2b6abc6a43549a024ea6"},
-    {file = "astroid-2.4.0.tar.gz", hash = "sha256:29fa5d46a2404d01c834fcb802a3943685f1fc538eb2a02a161349f5505ac196"},
+    {file = "astroid-2.3.0-py3-none-any.whl", hash = "sha256:9b3f17b0550f82e28a6776a4e5222441f48e523b0773df4bc505bb6b7c2093b7"},
+    {file = "astroid-2.3.0.tar.gz", hash = "sha256:c7e2e5773d87ccc00d01c273e439386f4d6d63cce61317a79ccce5880162f9fb"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -1251,6 +1276,15 @@ idna = [
 importlib-metadata = [
     {file = "importlib_metadata-1.6.0-py2.py3-none-any.whl", hash = "sha256:2a688cbaa90e0cc587f1df48bdc97a6eadccdcd9c35fb3f976a09e3b5016d90f"},
     {file = "importlib_metadata-1.6.0.tar.gz", hash = "sha256:34513a8a0c4962bc66d35b359558fd8a5e10cd472d37aec5f66858addef32c1e"},
+]
+invoke = [
+    {file = "invoke-0.22.1-py2-none-any.whl", hash = "sha256:357f0661c1d84f9f113e6164705d92eb00b35cd704c31e82efbf0f012f25e40c"},
+    {file = "invoke-0.22.1-py3-none-any.whl", hash = "sha256:39020b07218c87747e85dd422510f02a8d1282c71952942324c67d9eeaae8e62"},
+    {file = "invoke-0.22.1.tar.gz", hash = "sha256:621181a0efae67b3dadec583cf2c6b5096136635bf6a326c481c73db412b36fc"},
+]
+invoke-release = [
+    {file = "invoke-release-4.5.2.tar.gz", hash = "sha256:261acfa8908fa9f933d38991d9bbfee07e89a2658f35254a2645e45da89b6511"},
+    {file = "invoke_release-4.5.2-py2.py3-none-any.whl", hash = "sha256:e429ec3b051be80d22df6c6e6b50e9c533b9d904b835c80afea721d85a0c0d12"},
 ]
 isort = [
     {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
@@ -1422,8 +1456,8 @@ pydantic = [
     {file = "pydantic-1.5.1.tar.gz", hash = "sha256:f0018613c7a0d19df3240c2a913849786f21b6539b9f23d85ce4067489dfacfa"},
 ]
 pylint = [
-    {file = "pylint-2.5.0-py3-none-any.whl", hash = "sha256:bd556ba95a4cf55a1fc0004c00cf4560b1e70598a54a74c6904d933c8f3bd5a8"},
-    {file = "pylint-2.5.0.tar.gz", hash = "sha256:588e114e3f9a1630428c35b7dd1c82c1c93e1b0e78ee312ae4724c5e1a1e0245"},
+    {file = "pylint-2.4.4-py3-none-any.whl", hash = "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"},
+    {file = "pylint-2.4.4.tar.gz", hash = "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
@@ -1519,8 +1553,8 @@ serverlessrepo = [
     {file = "serverlessrepo-0.1.9.tar.gz", hash = "sha256:0c340d0e4437b5043eed2f2aafcb8fd6b16ab3d62ace19e70186542f4f7ac0f5"},
 ]
 six = [
-    {file = "six-1.14.0-py2.py3-none-any.whl", hash = "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"},
-    {file = "six-1.14.0.tar.gz", hash = "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a"},
+    {file = "six-1.11.0-py2.py3-none-any.whl", hash = "sha256:832dc0e10feb1aa2c68dcc57dbb658f1c7e65b9b61af69048abc87a2db00a0eb"},
+    {file = "six-1.11.0.tar.gz", hash = "sha256:70e8a77beed4562e7f14fe23a786b54f6296e34344c23bc42f07b15018ff98e9"},
 ]
 starlette = [
     {file = "starlette-0.13.2-py3-none-any.whl", hash = "sha256:6169ee78ded501095d1dda7b141a1dc9f9934d37ad23196e180150ace2c6449b"},
@@ -1587,8 +1621,8 @@ uvloop = [
     {file = "uvloop-0.14.0.tar.gz", hash = "sha256:123ac9c0c7dd71464f58f1b4ee0bbd81285d96cdda8bc3519281b8973e3a461e"},
 ]
 virtualenv = [
-    {file = "virtualenv-20.0.18-py2.py3-none-any.whl", hash = "sha256:5021396e8f03d0d002a770da90e31e61159684db2859d0ba4850fbea752aa675"},
-    {file = "virtualenv-20.0.18.tar.gz", hash = "sha256:ac53ade75ca189bc97b6c1d9ec0f1a50efe33cbf178ae09452dcd9fd309013c1"},
+    {file = "virtualenv-20.0.19-py2.py3-none-any.whl", hash = "sha256:b86480fc1fe3908a85d7377eee8dc9644a58090b9d3a3701b347c69c308f3e72"},
+    {file = "virtualenv-20.0.19.tar.gz", hash = "sha256:8bb59b586fea2eb3bb5600f7ef53d11fd4a64806cdf1a7217b29e7d943dbd8dc"},
 ]
 wcwidth = [
     {file = "wcwidth-0.1.9-py2.py3-none-any.whl", hash = "sha256:cafe2186b3c009a04067022ce1dcd79cb38d8d65ee4f4791b8888d6599d1bbe1"},
@@ -1627,8 +1661,8 @@ werkzeug = [
     {file = "Werkzeug-1.0.1.tar.gz", hash = "sha256:6c80b1e5ad3665290ea39320b91e1be1e0d5f60652b964a3070216de83d2e47c"},
 ]
 wheel = [
-    {file = "wheel-0.34.2-py2.py3-none-any.whl", hash = "sha256:df277cb51e61359aba502208d680f90c0493adec6f0e848af94948778aed386e"},
-    {file = "wheel-0.34.2.tar.gz", hash = "sha256:8788e9155fe14f54164c1b9eb0a319d98ef02c160725587ad60f14ddc57b6f96"},
+    {file = "wheel-0.31.1-py2.py3-none-any.whl", hash = "sha256:80044e51ec5bbf6c894ba0bc48d26a8c20a9ba629f4ca19ea26ecfcf87685f5f"},
+    {file = "wheel-0.31.1.tar.gz", hash = "sha256:0a2e54558a0628f2145d2fc822137e322412115173e8a2ddbe1c9024338ae83c"},
 ]
 whichcraft = [
     {file = "whichcraft-0.6.1-py2.py3-none-any.whl", hash = "sha256:deda9266fbb22b8c64fd3ee45c050d61139cd87419765f588e37c8d23e236dd9"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,14 @@ description = ""
 authors = ["Darren Weber <dweber.consulting@gmail.com>"]
 license = "MIT"
 
+include = ["example_app/**/*"]
+exclude = ["tests/**/*"]
+
+packages = [
+    {include = "example_app"}
+]
+
+
 [tool.poetry.dependencies]
 python = "~3.7.0"
 fastapi = "^0.54.1"
@@ -15,13 +23,14 @@ mangum = "^0.8.0"
 awscli = "~1.18"
 aws-sam-cli = "~0.48"
 black = "^19.10b0"
+invoke-release = "~4.0"
+mypy = "^0.770"
 pre-commit = "^2.3.0"
+pylint = "~2.0"
 pytest = "~5.4"
+pytest-cov = "^2.8.1"
 requests = "~2.23"
 uvicorn = "^0.11.5"
-pytest-cov = "^2.8.1"
-pylint = "^2.5.0"
-mypy = "^0.770"
 
 [build-system]
 requires = ["poetry>=0.12"]

--- a/scripts/example.py
+++ b/scripts/example.py
@@ -1,19 +1,27 @@
 #!/usr/bin/env python
 
-import requests
+import os
 from pprint import pprint
 
-BASE_URI = "http://127.0.0.1:8000"
+import requests
 
-url = f"{BASE_URI}/ping"
+APP_ENDPOINT = os.getenv("APP_ENDPOINT", "http://127.0.0.1:8000")
+print("APP_ENDPOINT: " + APP_ENDPOINT)
+print()
+
+url = f"{APP_ENDPOINT}/ping"
 response = requests.get(url)
 data = response.json()
+print("Response for: " + url)
 pprint(data, indent=4)
+print()
 
-url = f"{BASE_URI}/api/v1/example"
+url = f"{APP_ENDPOINT}/api/v1/example"
 a = 5
 b = 5
 payload = {"a": a, "b": b}
 response = requests.post(url, json=payload)
 data = response.json()
+print("Response for: " + url)
 pprint(data, indent=4)
+print()

--- a/scripts/mangum_http_event.py
+++ b/scripts/mangum_http_event.py
@@ -1,0 +1,58 @@
+# Adapted from test fixture data in
+# https://github.com/erm/mangum/blob/master/tests/
+
+mock_http_event = {
+    "path": "/ping",
+    "body": None,
+    "headers": {
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "Accept-Encoding": "gzip, deflate, lzma, sdch, br",
+        "Accept-Language": "en-US,en;q=0.8",
+        "CloudFront-Forwarded-Proto": "https",
+        "CloudFront-Is-Desktop-Viewer": "true",
+        "CloudFront-Is-Mobile-Viewer": "false",
+        "CloudFront-Is-SmartTV-Viewer": "false",
+        "CloudFront-Is-Tablet-Viewer": "false",
+        "CloudFront-Viewer-Country": "US",
+        "Host": "test.execute-api.us-west-2.amazonaws.com",
+        "Upgrade-Insecure-Requests": "1",
+        "X-Forwarded-For": "192.168.100.1, 192.168.1.1",
+        "X-Forwarded-Port": "443",
+        "X-Forwarded-Proto": "https",
+    },
+    "pathParameters": {"proxy": "hello"},
+    "requestContext": {
+        "accountId": "123456789012",
+        "resourceId": "us4z18",
+        "stage": "dev",
+        "requestId": "41b45ea3-70b5-11e6-b7bd-69b5aaebc7d9",
+        "identity": {
+            "cognitoIdentityPoolId": "",
+            "accountId": "",
+            "cognitoIdentityId": "",
+            "caller": "",
+            "apiKey": "",
+            "sourceIp": "192.168.100.1",
+            "cognitoAuthenticationType": "",
+            "cognitoAuthenticationProvider": "",
+            "userArn": "",
+            "userAgent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/52.0.2743.82 Safari/537.36 OPR/39.0.2256.48",
+            "user": "",
+        },
+        "resourcePath": "/{proxy+}",
+        "httpMethod": "GET",
+        "apiId": "123",
+    },
+    "resource": "/{proxy+}",
+    "httpMethod": "GET",
+    "queryStringParameters": None,
+    "multiValueQueryStringParameters": None,
+    "stageVariables": {"stageVarName": "stageVarValue"},
+}
+
+
+if __name__ == "__main__":
+
+    import json
+
+    print(json.dumps(mock_http_event))

--- a/scripts/package_lambda.sh
+++ b/scripts/package_lambda.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+PARENT_DIR=$(realpath "${SCRIPT_DIR}/..")
+
+
+# See also
+# https://docs.aws.amazon.com/lambda/latest/dg/limits.html
+# - Function and layer storage: 75 GB
+# - Deployment package size
+#   - 50 MB (zipped, for direct upload)
+#   - 250 MB (unzipped, including layers)
+#   - 3 MB (console editor)
+
+# AWS lambda bundles the python SDK in lambda layers, but advise that bundling it into
+# a layer is a best practice.
+# https://aws.amazon.com/blogs/compute/upcoming-changes-to-the-python-sdk-in-aws-lambda/
+#
+# See also the current versions of botocore in lambda - listed at
+# https://docs.aws.amazon.com/lambda/latest/dg/lambda-python.html
+#
+# Also consider what is supported by aiobotocore, see:
+# https://github.com/aio-libs/aiobotocore/blob/master/setup.py
+
+# To sync layers to s3
+# cp /tmp/*.zip layers/
+# aws s3 sync layers/ s3://<your-bucket>/<app>
+
+export PYTHONDONTWRITEBYTECODE=true
+
+clean_python_packages () {
+  site=$1
+  find "$site" -type d -name '__pycache__' -exec rm -rf {} +
+  find "$site" -type d -name 'tests' -exec rm -rf {} +
+  #find "$site" -type d -name '*.dist-info' -exec rm -rf {} +
+  #find "$site" -type d -name '*.egg-info' -exec rm -rf {} +
+  #find "$site" -type d -name 'datasets' -exec rm -rf {} +
+}
+
+clean_boto3 () {
+  site=$1
+  find "$site" -type d -name 'boto3' -exec rm -rf {} +
+  find "$site" -type d -name 'botocore' -exec rm -rf {} +
+  find "$site" -type d -name 'aiobotocore' -exec rm -rf {} +
+}
+
+crash () {
+  echo
+  echo "OOPS - something went wrong!"
+  echo
+  exit 1
+}
+
+# The destination path should be where AWS lambda unpacks a layer .zip file
+prefix="${PREFIX:-/opt}"
+dst=${prefix}/python/lib/python${py_version}/site-packages
+mkdir -p "${dst}"
+
+#
+# Note: similar variable names are in Makefile and terraform/*.tf
+#
+py_version="${APP_PY_VERSION:-3.7}"
+py_ver="${APP_PY_VER:-py37}"
+
+package="${APP_PACKAGE:-serverless-fast-api}"
+version="${APP_VERSION:-0.1.0}"
+
+app_name="${package}-${version}"
+app_package="${py_ver}-${app_name}-app"
+layer_package="${py_ver}-${app_name}-layer"
+
+echo
+echo "Building:"
+echo "$app_package"
+echo "$layer_package"
+echo
+
+#
+# Application zip
+#
+
+pushd "$PARENT_DIR" || crash
+
+make clean
+zip_file="/tmp/${app_package}.zip"
+rm -f "${zip_file}"
+zip -q -r9 --symlinks "${zip_file}" example_app/*
+unzip -t "${zip_file}" || crash
+echo "created ${zip_file}"
+cp -vp "${zip_file}" "${PARENT_DIR}/terraform/"
+echo
+echo
+
+# TODO: when the app package and the code-dir are in sync,
+#       change this to use poetry build and install the package
+python ./scripts/poetry_requirements.py > /tmp/requirements.txt
+
+popd || crash
+
+#
+# Dependencies layer zip
+#
+
+## Use `poetry show -t --no-dev`, `pip freeze` or `pipdeptree` to check poetry installed
+## versions and pin common deps to use the same, consistent versions in lambda layers.
+
+pushd "$prefix" || crash
+rm -rf "${dst:?}"/*
+python -m pip install -t "$dst" -r /tmp/requirements.txt
+clean_python_packages "$dst"
+python -m pip list --path "$dst"
+zip_file="/tmp/${layer_package}.zip"
+rm -f "${zip_file}"
+zip -q -r9 --symlinks "${zip_file}" python
+unzip -q -t "${zip_file}" || crash
+echo "created ${zip_file}"
+cp -vp "${zip_file}" "${PARENT_DIR}/terraform/"
+echo
+echo
+popd || crash
+
+# TODO: why does this fail to list the zip files - they exist OK - weird?
+#echo
+#echo "Outputs"
+#ls -al "${PARENT_DIR}/terraform/${py_ver}-${app_name}*"
+#echo

--- a/tasks.py
+++ b/tasks.py
@@ -1,0 +1,21 @@
+"""
+Configure the invoke release task
+"""
+
+from invoke_release.tasks import *  # noqa: F403
+from invoke_release.plugins import PatternReplaceVersionInFilesPlugin
+
+configure_release_parameters(  # noqa: F405
+    module_name="serverless-fast-api",
+    display_name="Serverless AWS FastAPI",
+    python_directory="example_app",
+    plugins=[
+        PatternReplaceVersionInFilesPlugin(
+            "pyproject.toml",
+            "README.md",
+            "Makefile",
+            "example_app/version.py",
+            "terraform/variables.tf",
+        )
+    ],
+)

--- a/terraform/aws_api_gateway.tf
+++ b/terraform/aws_api_gateway.tf
@@ -1,0 +1,4 @@
+resource "aws_api_gateway_rest_api" "fast_api_gw" {
+  name        = "fast_api"
+  description = "FastAPI Serverless Application"
+}

--- a/terraform/aws_lambda.tf
+++ b/terraform/aws_lambda.tf
@@ -1,0 +1,136 @@
+#
+# https://www.terraform.io/docs/providers/aws/r/lambda_function.html
+#
+# https://iwpnd.pw/articles/2020-01/deploy-fastapi-to-aws-lambda
+#
+# https://learn.hashicorp.com/terraform/aws/lambda-api-gateway
+#
+
+# aws s3api create-bucket --bucket=terraform-serverless-deploys
+#    --acl=public-read \
+#    --create-bucket-configuration='{"LocationConstraint": "us-west-2"}'
+#    --region=us-west-2
+
+
+provider "aws" {
+  profile = var.aws_default_profile
+  region  = var.region
+  version = "~> 2.31"
+}
+
+resource "aws_iam_role" "iam_for_lambda" {
+  name = "iam_for_${var.app_name}"
+
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Effect": "Allow",
+      "Sid": ""
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_lambda_layer_version" "fast_api_app_layer" {
+  filename   = "${var.py_ver}-${var.project_name}-${var.app_version}-layer.zip"
+  layer_name = "${var.app_name}_${var.app_stage}_layer"
+}
+
+resource "aws_lambda_function" "fast_api_app_function" {
+  //  # The bucket name as created earlier with "aws s3api create-bucket" - not used yet
+  //  s3_bucket = "terraform-serverless-deploys"
+  //  s3_key    = "${var.project_name}/${var.project_name}-${var.app_version}-${var.app_stage}.zip"
+
+  filename      = "${var.py_ver}-${var.project_name}-${var.app_version}-app.zip"
+  function_name = "${var.app_name}_${var.app_stage}_app"
+  role          = aws_iam_role.iam_for_lambda.arn
+
+  handler     = "example_app.main.handler"
+  memory_size = 128
+  timeout     = 30
+
+  layers = [aws_lambda_layer_version.fast_api_app_layer.arn]
+
+  source_code_hash = filebase64sha256(aws_lambda_layer_version.fast_api_app_layer.filename)
+
+  runtime = var.runtime
+
+  //  environment {
+  //    variables = {
+  //      foo = "bar"
+  //    }
+  //  }
+}
+
+
+resource "aws_api_gateway_resource" "fast_api_proxy" {
+  rest_api_id = aws_api_gateway_rest_api.fast_api_gw.id
+  parent_id   = aws_api_gateway_rest_api.fast_api_gw.root_resource_id
+  path_part   = "{proxy+}"
+}
+
+resource "aws_api_gateway_method" "fast_api_proxy" {
+  rest_api_id   = aws_api_gateway_rest_api.fast_api_gw.id
+  resource_id   = aws_api_gateway_resource.fast_api_proxy.id
+  http_method   = "ANY"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "fast_api_lambda" {
+  rest_api_id = aws_api_gateway_rest_api.fast_api_gw.id
+  resource_id = aws_api_gateway_method.fast_api_proxy.resource_id
+  http_method = aws_api_gateway_method.fast_api_proxy.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.fast_api_app_function.invoke_arn
+}
+
+resource "aws_api_gateway_method" "fast_api_proxy_root" {
+  rest_api_id   = aws_api_gateway_rest_api.fast_api_gw.id
+  resource_id   = aws_api_gateway_rest_api.fast_api_gw.root_resource_id
+  http_method   = "ANY"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_integration" "fast_api_lambda_root" {
+  rest_api_id = aws_api_gateway_rest_api.fast_api_gw.id
+  resource_id = aws_api_gateway_method.fast_api_proxy_root.resource_id
+  http_method = aws_api_gateway_method.fast_api_proxy_root.http_method
+
+  integration_http_method = "POST"
+  type                    = "AWS_PROXY"
+  uri                     = aws_lambda_function.fast_api_app_function.invoke_arn
+}
+
+resource "aws_api_gateway_deployment" "fast_api" {
+  depends_on = [
+    aws_api_gateway_integration.fast_api_lambda,
+    aws_api_gateway_integration.fast_api_lambda_root,
+  ]
+
+  rest_api_id = aws_api_gateway_rest_api.fast_api_gw.id
+  stage_name  = var.app_stage
+}
+
+resource "aws_lambda_permission" "fast_api_gw" {
+  statement_id  = "AllowAPIGatewayInvoke"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.fast_api_app_function.function_name
+  principal     = "apigateway.amazonaws.com"
+
+  # The "/*/*" portion grants access from any method on any resource
+  # within the API Gateway REST API.
+  source_arn = "${aws_api_gateway_rest_api.fast_api_gw.execution_arn}/*/*"
+}
+
+output "APP_ENDPOINT" {
+  value = aws_api_gateway_deployment.fast_api.invoke_url
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,44 @@
+variable "aws_default_profile" {
+  default = "consulting"
+}
+
+variable "region" {
+  default = "us-west-2"
+}
+
+# The pyproject.toml defines the python version etc., keep these in sync;
+# See also Makefile definitions.
+
+variable "runtime" {
+  default = "python3.7"
+}
+
+variable "py_version" {
+  default = "3.7"
+}
+
+variable "py_ver" {
+  default = "py37"
+}
+
+variable "project_name" {
+  default = "serverless-fast-api"
+}
+
+variable "app_name" {
+  default = "fastapi_demo"
+}
+
+# invoke-release manages this version string, via tasks.py
+
+variable "app_version" {
+  default = "0.1.0"
+}
+
+variable "app_stage" {
+  default = "dev"
+}
+
+variable "app_s3_bucket" {
+  default = "terraform-serverless-deploys"
+}

--- a/tests/test_ping.py
+++ b/tests/test_ping.py
@@ -8,3 +8,12 @@ client = TestClient(app)
 def test_ping():
     response = client.get("/ping")
     assert response.status_code == 200
+    data = response.json()
+    assert data["ping"] == "pong!"
+
+
+def test_app_version():
+    response = client.get("/ping")
+    assert response.status_code == 200
+    data = response.json()
+    assert data["version"] == app.VERSION


### PR DESCRIPTION
- add app-version details and management with
  invoke-release and tasks.py
- deployment is a mish-mash of make rules,
  zip-file creation in scripts/package_lambda.sh,
  and terraform specs in terraform/*.tf; it's OK
  but it's a bit fragile.